### PR TITLE
Remove API documentation from help

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,4 +1,2 @@
 - name: Benutzerhandbuch
   href: articles/
-- name: Programmierschnittstelle
-  href: api/


### PR DESCRIPTION
As it can't be generated with the current version of mono on *nix
systems.

#27 