### PR TITLE
Do not retrieve unneeded objects when searching Bohrungen

### DIFF
--- a/src/ClientApp/cypress/integration/bohrprofilform.spec.js
+++ b/src/ClientApp/cypress/integration/bohrprofilform.spec.js
@@ -4,6 +4,8 @@ import standorte from "../fixtures/standorte.json";
 describe("Input form tests", () => {
   beforeEach(() => {
     cy.intercept("/standort", standorte);
+    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    cy.intercept("/standort/" + standort.id, standort);
     cy.intercept(
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",
       standorteGemeinde

--- a/src/ClientApp/cypress/integration/bohrprofilform.spec.js
+++ b/src/ClientApp/cypress/integration/bohrprofilform.spec.js
@@ -4,7 +4,7 @@ import standorte from "../fixtures/standorte.json";
 describe("Input form tests", () => {
   beforeEach(() => {
     cy.intercept("/standort", standorte);
-    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    const standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
     cy.intercept("/standort/" + standort.id, standort);
     cy.intercept(
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",

--- a/src/ClientApp/cypress/integration/home.spec.js
+++ b/src/ClientApp/cypress/integration/home.spec.js
@@ -60,7 +60,7 @@ describe("Home page tests", () => {
   it("Open Standort Edit Form", function () {
     cy.intercept("/standort", standorte);
 
-    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    const standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
     cy.intercept("/standort/" + standort.id, standort);
 
     cy.intercept(
@@ -121,7 +121,7 @@ describe("Home page tests", () => {
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",
       standorteGemeinde
     );
-    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
+    const standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
     cy.intercept("/standort/" + standort.id, standort);
 
     cy.intercept("/user/self", userInRoleSachbearbeiterAfu);
@@ -164,7 +164,7 @@ describe("Home page tests", () => {
     });
     it("is available for users in role 'SachbearbeiterAfU'", () => {
       cy.intercept("/standort*", standorteGemeinde);
-      let standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
+      const standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
       cy.intercept("/standort/" + standort.id, standort);
 
       cy.intercept("/user/self", userInRoleSachbearbeiterAfu);
@@ -176,7 +176,7 @@ describe("Home page tests", () => {
     });
     it("is available for users in role 'Administrator'", () => {
       cy.intercept("/standort*", standorteGemeinde);
-      let standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
+      const standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
       cy.intercept("/standort/" + standort.id, standort);
       cy.intercept("/user/self", userInRoleAdministrator);
       cy.visit("/");

--- a/src/ClientApp/cypress/integration/home.spec.js
+++ b/src/ClientApp/cypress/integration/home.spec.js
@@ -60,6 +60,9 @@ describe("Home page tests", () => {
   it("Open Standort Edit Form", function () {
     cy.intercept("/standort", standorte);
 
+    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    cy.intercept("/standort/" + standort.id, standort);
+
     cy.intercept(
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",
       standorteGemeinde
@@ -113,7 +116,14 @@ describe("Home page tests", () => {
   });
 
   it("Check and uncheck AfU Freigabe", function () {
-    cy.intercept("/standort*", standorteGemeinde);
+    cy.intercept("/standort", standorte);
+    cy.intercept(
+      "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",
+      standorteGemeinde
+    );
+    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
+    cy.intercept("/standort/" + standort.id, standort);
+
     cy.intercept("/user/self", userInRoleSachbearbeiterAfu);
     cy.intercept("PUT", "/standort").as("editStandortFreigabe");
 
@@ -154,6 +164,9 @@ describe("Home page tests", () => {
     });
     it("is available for users in role 'SachbearbeiterAfU'", () => {
       cy.intercept("/standort*", standorteGemeinde);
+      let standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
+      cy.intercept("/standort/" + standort.id, standort);
+
       cy.intercept("/user/self", userInRoleSachbearbeiterAfu);
       cy.visit("/");
       cy.get("div[name=gemeinde] input").should("be.visible").click({ force: true }).type("Hein{downarrow}{enter}");
@@ -163,6 +176,8 @@ describe("Home page tests", () => {
     });
     it("is available for users in role 'Administrator'", () => {
       cy.intercept("/standort*", standorteGemeinde);
+      let standort = standorteGemeinde.find((s) => s.bezeichnung === "Generic Steel Pants");
+      cy.intercept("/standort/" + standort.id, standort);
       cy.intercept("/user/self", userInRoleAdministrator);
       cy.visit("/");
       cy.get("div[name=gemeinde] input").should("be.visible").click({ force: true }).type("Hein{downarrow}{enter}");

--- a/src/ClientApp/cypress/integration/inputform.spec.js
+++ b/src/ClientApp/cypress/integration/inputform.spec.js
@@ -4,6 +4,8 @@ import standorte from "../fixtures/standorte.json";
 describe("Input form tests", () => {
   beforeEach(() => {
     cy.intercept("/standort", standorte);
+    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    cy.intercept("/standort/" + standort.id, standort);
     cy.intercept(
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",
       standorteGemeinde

--- a/src/ClientApp/cypress/integration/inputform.spec.js
+++ b/src/ClientApp/cypress/integration/inputform.spec.js
@@ -4,7 +4,7 @@ import standorte from "../fixtures/standorte.json";
 describe("Input form tests", () => {
   beforeEach(() => {
     cy.intercept("/standort", standorte);
-    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    const standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
     cy.intercept("/standort/" + standort.id, standort);
     cy.intercept(
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",

--- a/src/ClientApp/cypress/integration/schichtenform.spec.js
+++ b/src/ClientApp/cypress/integration/schichtenform.spec.js
@@ -4,6 +4,8 @@ import standorte from "../fixtures/standorte.json";
 describe("Input form tests", () => {
   beforeEach(() => {
     cy.intercept("/standort", standorte);
+    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    cy.intercept("/standort/" + standort.id, standort);
     cy.intercept(
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",
       standorteGemeinde

--- a/src/ClientApp/cypress/integration/schichtenform.spec.js
+++ b/src/ClientApp/cypress/integration/schichtenform.spec.js
@@ -4,7 +4,7 @@ import standorte from "../fixtures/standorte.json";
 describe("Input form tests", () => {
   beforeEach(() => {
     cy.intercept("/standort", standorte);
-    let standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
+    const standort = standorteGemeinde.find((s) => s.bezeichnung === "Ergonomic Metal Tuna");
     cy.intercept("/standort/" + standort.id, standort);
     cy.intercept(
       "/standort?gemeinde=Heinrichswil-Winistorf&gbnummer=&bezeichnung=&erstellungsdatum=&mutationsdatum=",

--- a/src/ClientApp/src/components/InputForm.js
+++ b/src/ClientApp/src/components/InputForm.js
@@ -16,7 +16,7 @@ export default function InputForm(props) {
     setShowAlert,
     setAlertMessage,
     setAlertVariant,
-    getStandort,
+    getAndSetCurrentStandort,
     currentUser,
   } = props;
 
@@ -53,7 +53,7 @@ export default function InputForm(props) {
       setShowAlert(true);
       setAlertMessage("Bohrung wurde hinzugefügt.");
       setAlertVariant("success");
-      getStandort(addedBohrung.standortId);
+      getAndSetCurrentStandort(addedBohrung.standortId);
       handleBack();
     } else {
       setShowAlert(true);
@@ -84,7 +84,7 @@ export default function InputForm(props) {
       setShowAlert(true);
       setAlertMessage("Bohrung wurde editiert.");
       setAlertVariant("success");
-      getStandort(updatedBohrung.standortId);
+      getAndSetCurrentStandort(updatedBohrung.standortId);
       handleBack();
     } else {
       setShowAlert(true);
@@ -101,7 +101,7 @@ export default function InputForm(props) {
       method: "DELETE",
     });
     if (response.ok) {
-      getStandort(bohrung.standortId);
+      getAndSetCurrentStandort(bohrung.standortId);
       setShowAlert(true);
       setAlertMessage("Bohrung wurde gelöscht.");
       setAlertVariant("success");

--- a/src/ClientApp/src/components/pages/Home.js
+++ b/src/ClientApp/src/components/pages/Home.js
@@ -39,7 +39,7 @@ export function Home(props) {
   };
 
   const onEditStandort = (standort) => {
-    setCurrentStandort(standort);
+    getAndSetCurrentStandort(standort.id);
     setOpenStandortForm(true);
   };
 
@@ -73,7 +73,7 @@ export function Home(props) {
   }
 
   // Get standort by Id
-  async function getStandort(id) {
+  async function getAndSetCurrentStandort(id) {
     const response = await fetch("/standort/" + id);
     if (response.ok) {
       const standort = await response.json();
@@ -120,7 +120,7 @@ export function Home(props) {
       body: JSON.stringify(updatedStandort),
     });
     if (response.ok) {
-      getStandort(updatedStandort.id);
+      getAndSetCurrentStandort(updatedStandort.id);
       setShowAlert(true);
       setAlertMessage("Standort wurde editiert.");
     }
@@ -242,7 +242,7 @@ export function Home(props) {
             showAlert={showAlert}
             setShowAlert={setShowAlert}
             setAlertMessage={setAlertMessage}
-            getStandort={getStandort}
+            getAndSetCurrentStandort={getAndSetCurrentStandort}
             setAlertVariant={setAlertVariant}
             currentUser={currentUser}
           ></InputForm>

--- a/src/ClientApp/src/components/pages/Home.js
+++ b/src/ClientApp/src/components/pages/Home.js
@@ -38,8 +38,8 @@ export function Home(props) {
     setOpenStandortForm(true);
   };
 
-  const onEditStandort = (standort) => {
-    getAndSetCurrentStandort(standort.id);
+  const onEditStandort = async (standort) => {
+    await getAndSetCurrentStandort(standort.id);
     setOpenStandortForm(true);
   };
 


### PR DESCRIPTION
Improves site loading speed as no unneeded data gets transfered to show the map.
On the other hand, when editing a Standort always get the current state from the database for the edit form.

Resolves #161 