### PR TITLE
Only mark coords as dirty when clicking on map

### DIFF
--- a/src/ClientApp/src/components/BohrungForm.js
+++ b/src/ClientApp/src/components/BohrungForm.js
@@ -94,8 +94,9 @@ export default function BohrungForm(props) {
     if (currentBohrung?.geometrie?.coordinates) {
       const x = currentBohrung.geometrie.coordinates[0];
       const y = currentBohrung.geometrie.coordinates[1];
-      setValue("x_coordinate", x.toFixed(1), { shouldDirty: true });
-      setValue("y_coordinate", y.toFixed(1), { shouldDirty: true });
+      const changedFromMapClick = currentBohrung.coordinatesChanged;
+      setValue("x_coordinate", x.toFixed(1), { shouldDirty: changedFromMapClick });
+      setValue("y_coordinate", y.toFixed(1), { shouldDirty: changedFromMapClick });
       currentBohrung.coordinatesChanged = false;
     }
   }, [currentBohrung, setValue]);


### PR DESCRIPTION
Beim Öffnen der BohrungsForm ist der Speichern-Button deaktiviert und wird erst durch Änderungen (z.B. beim Klicken auf die Map) aktiviert.

Behebt den Fehler beim cypress Test "Open Bohrung Edit Form": expected [...] (submit button) to be 'disabled'

Related #287 #289