### PR TITLE
Explicitly configure the MigrationsHistoryTable

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -57,7 +57,15 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<DataService>();
 
 var connectionString = builder.Configuration.GetConnectionString("BohrungContext");
-builder.Services.AddDbContext<EwsContext>(x => x.UseNpgsql(connectionString, option => option.UseNetTopologySuite().UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)));
+builder.Services.AddDbContext<EwsContext>(x =>
+{
+    x.UseNpgsql(connectionString, options =>
+    {
+        options.UseNetTopologySuite().UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+        options.MigrationsHistoryTable("__EFMigrationsHistory", "bohrung");
+    });
+});
+
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
 var app = builder.Build();


### PR DESCRIPTION
Otherwise the table is searched in another db schema in some cases.

https://github.com/GeoWerkstatt/ews-boda/issues/323